### PR TITLE
Add WebSocket `ProxyPass` and `ProxyPassReverse` directives to CAS Apache examples

### DIFF
--- a/CAS/remoteUserAuth/mod_auth_cas.markdown
+++ b/CAS/remoteUserAuth/mod_auth_cas.markdown
@@ -93,6 +93,8 @@ If anything fails, please check that you have all of the module’s dependencies
         </RequireAny>
       </LocationMatch>
 
-      ProxyPass / ajp://<internal-ip>:8009/
-      ProxyPassReverse / ajp://<internal-ip>:8009/
+      ProxyPass         /websocket ws://<internal-ip>:8080/websocket
+      ProxyPassReverse  /websocket ws://<internal-ip>:8080/websocket
+      ProxyPass         / ajp://<internal-ip>:8009/
+      ProxyPassReverse  / ajp://<internal-ip>:8009/
     </VirtualHost>

--- a/CAS/remoteUserAuth/remoteuserauth-httpd.conf
+++ b/CAS/remoteUserAuth/remoteuserauth-httpd.conf
@@ -46,9 +46,11 @@ CASIdleTimeout 3600
 	Allow from all
     </LocationMatch>
 
-    ProxyPass        /robots.txt !
-    ProxyPass        / ajp://localhost:8012/
-    ProxyPassReverse / ajp://localhost:8012/
+    ProxyPass           /robots.txt !
+    ProxyPass           /websocket ws://localhost:8080/websocket
+    ProxyPassReverse    /websocket ws://localhost:8080/websocket
+    ProxyPass           / ajp://localhost:8012/
+    ProxyPassReverse    / ajp://localhost:8012/
 </VirtualHost>
 
 
@@ -80,8 +82,10 @@ CASIdleTimeout 3600
 	Allow from .usask.ca	# web services is available on-campus
     </LocationMatch>
 
-    ProxyPass        /robots.txt !
-    ProxyPass        / ajp://localhost:8012/
-    ProxyPassReverse / ajp://localhost:8012/
+    ProxyPass           /robots.txt !
+    ProxyPass           /websocket ws://localhost:8080/websocket
+    ProxyPassReverse    /websocket ws://localhost:8080/websocket
+    ProxyPass           / ajp://localhost:8012/
+    ProxyPassReverse    / ajp://localhost:8012/
 </VirtualHost>
 


### PR DESCRIPTION
The current documentation and examples for CAS don't mention the need to proxy WebSocket connections, so I've added directives to the example Apache configurations to pass those connections through.